### PR TITLE
ttc-connectors-processing to 1.0.18

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -31,3 +31,6 @@ dependencies:
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.20
+- name: ttc-connectors-processing
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.18


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.18